### PR TITLE
Make the settings more visually appealing.

### DIFF
--- a/studio/app/src/main/res/layout/activity_main.xml
+++ b/studio/app/src/main/res/layout/activity_main.xml
@@ -68,17 +68,15 @@
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent" />
 
-        <ToggleButton
+        <android.support.v7.widget.SwitchCompat
             android:id="@+id/button_toggle_service"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/activity_horizontal_margin"
+            android:layout_marginEnd="@dimen/activity_horizontal_margin"
             android:layout_marginTop="@dimen/activity_vertical_margin"
             android:checked="@={model.serviceEnabled}"
             android:onClick="@{(view) -> presenter.enableService(view)}"
-            android:textOff="@string/button_disabled"
-            android:textOn="@string/button_enabled"
-            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
@@ -86,24 +84,22 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/activity_horizontal_margin"
-            android:layout_marginStart="8dp"
+            android:layout_marginStart="@dimen/activity_horizontal_margin"
             android:text="@string/text_service_explained"
             app:layout_constraintBottom_toBottomOf="@+id/button_toggle_service"
-            app:layout_constraintLeft_toRightOf="@+id/button_toggle_service"
-            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintRight_toLeftOf="@+id/button_toggle_service"
+            app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintTop_toTopOf="@+id/button_toggle_service" />
 
-        <ToggleButton
+        <android.support.v7.widget.SwitchCompat
             android:id="@+id/button_toggle_lock"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/activity_horizontal_margin"
+            android:layout_marginEnd="@dimen/activity_horizontal_margin"
             android:layout_marginTop="8dp"
             android:checked="@={model.wakeLocked}"
             android:onClick="@{(view) -> presenter.enableLock(view)}"
-            android:textOff="@string/button_released"
-            android:textOn="@string/button_acquired"
-            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/button_toggle_service" />
 
         <TextView
@@ -111,11 +107,11 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/activity_horizontal_margin"
-            android:layout_marginStart="8dp"
+            android:layout_marginStart="@dimen/activity_horizontal_margin"
             android:text="@string/text_lock_explained"
             app:layout_constraintBottom_toBottomOf="@+id/button_toggle_lock"
-            app:layout_constraintLeft_toRightOf="@+id/button_toggle_lock"
-            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintRight_toLeftOf="@+id/button_toggle_lock"
+            app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintTop_toTopOf="@+id/button_toggle_lock" />
 
     </android.support.constraint.ConstraintLayout>

--- a/studio/app/src/main/res/values/strings.xml
+++ b/studio/app/src/main/res/values/strings.xml
@@ -31,10 +31,6 @@
     <string name="grant_permission">Grant permission to read notifications</string>
     <string name="text_service_explained">Acquire/release wakelock on appear/disappear of ADB notification</string>
     <string name="text_lock_explained">Current wake lock state</string>
-    <string name="button_released">Released</string>
-    <string name="button_acquired">Acquired</string>
-    <string name="button_enabled">Enabled</string>
-    <string name="button_disabled">Disabled</string>
     <string name="service_name">ADB notification listener</string>
     <string name="about_version">Version %1$s (%2$s, build %3$d)</string>
     <string name="action_about">About</string>


### PR DESCRIPTION
 * Use SwitchCompat instead of ToggleButton.
 * Move the switches to the right, following material design conventions.
 * Make both margins of the screen symmetrical.